### PR TITLE
load dataset per job batch rather than once

### DIFF
--- a/toshi_hazard_post/aggregation.py
+++ b/toshi_hazard_post/aggregation.py
@@ -25,7 +25,6 @@ from toshi_hazard_post.logic_tree import HazardLogicTree
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    import pyarrow.dataset as ds
     from nzshm_common.location import CodedLocation
 
     from toshi_hazard_post.logic_tree import HazardComponentBranch
@@ -41,7 +40,7 @@ def generate_agg_jobs(
     imts: list[str],
     compatibility_key: str,
     component_branches: list['HazardComponentBranch'],
-    dataset: 'ds.Dataset',
+    # dataset: 'ds.Dataset',
 ) -> Generator[tuple[int, 'CodedLocation', str, Path], None, None]:
     gmms_digests = [branch.gmcm_hash_digest for branch in component_branches]
     sources_digests = [branch.source_hash_digest for branch in component_branches]
@@ -55,11 +54,9 @@ def generate_agg_jobs(
         locations = [site.location for site in sites if site.vs30 == vs30]
         location_bins = bin_locations(locations, PARTITION_RESOLUTION)
         for nloc_0, location_bin in location_bins.items():
+            dataset = get_realizations_dataset(vs30, nloc_0)
             log.info("batch %d, %s" % (vs30, nloc_0))
-            batch_datatable = get_batch_table(
-                dataset, compatibility_key, sources_digests, gmms_digests, nloc_0, vs30, imts
-            )
-
+            batch_datatable = get_batch_table(dataset, compatibility_key, sources_digests, gmms_digests, imts)
             for location, imt in itertools.product(location_bin.locations, imts):
                 job_datatable = get_job_datatable(batch_datatable, location, imt, n_expected)
                 working_dir = get_config()['WORKING_DIR']
@@ -140,14 +137,14 @@ def run_aggregation(args: AggregationArgs) -> None:
     log.info("starting %d calculations with %d workers" % (len(sites) * len(imts), num_workers))
 
     futures = {}
-    ds1 = get_realizations_dataset()
+    # ds1 = get_realizations_dataset()
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         for vs30, location, imt, filepath in generate_agg_jobs(
             sites,
             imts,
             args.general.compatibility_key,
             component_branches,
-            ds1,
+            # ds1,
         ):
             task_args = AggTaskArgs(
                 location=location,


### PR DESCRIPTION
Closes #76 

We see a small performance improvement. Test using 16 IMTs and two sets of loctions:
## Test 1
Over the `NZ` locations which are spread across several location bins
~5% speedup
```
chrisdc@glacier:~/.../APP/toshi-hazard-post (pre-release)$ poetry run python scripts/calc_time_v2.py base_NZ_IMT16_W10.log
Number of workers: 10
Total number of aggregate calculations: 576
Mean time to run Aggregation loop: 12.35 seconds
Total Time: 743.826 seconds
Mean time per calculation: 12.91 CPU seconds
Difference between total mean time per calculation and time to run aggregation function 0.56 seconds
chrisdc@glacier:~/.../APP/toshi-hazard-post (pre-release)$ poetry run python scripts/calc_time_v2.py effdataset_NZ_IMT16_W10.log 
Number of workers: 10
Total number of aggregate calculations: 576
Mean time to run Aggregation loop: 11.51 seconds
Total Time: 709.029 seconds
Mean time per calculation: 12.31 CPU seconds
Difference between total mean time per calculation and time to run aggregation function 0.80 seconds
```

## Test 2
Over 2 location bins of the 0.1 deg grid
~2% speedup
```
chrisdc@glacier:~/.../APP/toshi-hazard-post (pre-release)$ poetry run python scripts/calc_time_v2.py base_grid_IMT16_W10.log
Number of workers: 10
Total number of aggregate calculations: 1056
Mean time to run Aggregation loop: 9.43 seconds
Total Time: 1015.854 seconds
Mean time per calculation: 9.62 CPU seconds
Difference between total mean time per calculation and time to run aggregation function 0.19 seconds
chrisdc@glacier:~/.../APP/toshi-hazard-post (pre-release)$ poetry run python scripts/calc_time_v2.py effdataset_grid_IMT16_W10.log
Number of workers: 10
Total number of aggregate calculations: 1056
Mean time to run Aggregation loop: 9.26 seconds
Total Time: 993.905 seconds
Mean time per calculation: 9.41 CPU seconds
Difference between total mean time per calculation and time to run aggregation function 0.15 seconds

```

